### PR TITLE
Typo in JointType Check

### DIFF
--- a/KinectLib.Xbox360/Kinect360Manager.cs
+++ b/KinectLib.Xbox360/Kinect360Manager.cs
@@ -98,7 +98,7 @@ namespace KinectLib.Xbox360
                                 UpdateJoint(ref m_TrackingData.LeftTransform, joint, i);
                                 trackedBones++;
                             }
-                            else if (joint.JointType == JointType.HandLeft)
+                            else if (joint.JointType == JointType.HandRight)
                             {
                                 UpdateJoint(ref m_TrackingData.RightTransform, joint, i);
                                 trackedBones++;


### PR DESCRIPTION
"HandLeft" in check for "JointType" instead of "HandRight" prevented this code from transmitting the tracking data.